### PR TITLE
Akhaperskaya/change default deadletter policy

### DIFF
--- a/src/Framework.RabbitMq.Consumer/BackgroundServices/RabbitMqBackgroundService.cs
+++ b/src/Framework.RabbitMq.Consumer/BackgroundServices/RabbitMqBackgroundService.cs
@@ -49,7 +49,7 @@ internal class RabbitMqBackgroundService(
         this.ConsumerInitializer.Initialize(this._channel);
 
         this.Logger.LogInformation(
-            "Listening RabbitMQ events has started on {Address}. Queue name is {Queue}, Consumer mode is {Mode}",
+            "Listening RabbitMQ events has started on {Address}. Queue name is {Queue}. Consumer mode is {Mode}",
             this._serverSettings.Address,
             this._consumerSettings.Queue,
             this._consumerSettings.Mode);

--- a/src/Framework.RabbitMq.Consumer/BackgroundServices/RabbitMqBackgroundService.cs
+++ b/src/Framework.RabbitMq.Consumer/BackgroundServices/RabbitMqBackgroundService.cs
@@ -49,9 +49,10 @@ internal class RabbitMqBackgroundService(
         this.ConsumerInitializer.Initialize(this._channel);
 
         this.Logger.LogInformation(
-            "Listening RabbitMQ events has started on {Address}. Queue name is {Queue}",
+            "Listening RabbitMQ events has started on {Address}. Queue name is {Queue}, Consumer mode is {Mode}",
             this._serverSettings.Address,
-            this._consumerSettings.Queue);
+            this._consumerSettings.Queue,
+            this._consumerSettings.Mode);
 
         await this.Consumer.ConsumeAsync(this._channel!, stoppingToken);
     }

--- a/src/Framework.RabbitMq.Consumer/DependencyInjection.cs
+++ b/src/Framework.RabbitMq.Consumer/DependencyInjection.cs
@@ -19,23 +19,17 @@ public static class DependencyInjection
         settingsSection.Bind(settings);
 
         if (settings.Mode == ConsumerMode.MultipleActiveConsumers)
-        {
-            services
-                .AddSingleton<IRabbitMqConsumer, ConcurrentConsumer>();
-        }
+            services.AddSingleton<IRabbitMqConsumer, ConcurrentConsumer>();
         else
-        {
-            services
-                .AddSingleton<IRabbitMqConsumer, SynchronizedConsumer>();
-        }
+            services.AddSingleton<IRabbitMqConsumer, SynchronizedConsumer>();
 
         return services
-            .Configure<RabbitMqConsumerSettings>(settingsSection)
-            .AddSingleton<IRabbitMqMessageReader, MessageReader>()
-            .AddSingleton<IDeadLetterProcessor, DeadLetterProcessor>()
-            .AddSingleton<IRabbitMqMessageProcessor, TMessageProcessor>()
-            .AddSingleton<IRabbitMqConsumerInitializer, ConsumerInitializer>()
-            .AddHostedService<RabbitMqBackgroundService>();
+               .Configure<RabbitMqConsumerSettings>(settingsSection)
+               .AddSingleton<IRabbitMqMessageReader, MessageReader>()
+               .AddSingleton<IDeadLetterProcessor, DeadLetterProcessor>()
+               .AddSingleton<IRabbitMqMessageProcessor, TMessageProcessor>()
+               .AddSingleton<IRabbitMqConsumerInitializer, ConsumerInitializer>()
+               .AddHostedService<RabbitMqBackgroundService>();
     }
 
     public static IServiceCollection AddRabbitMqSqlServerConsumerLock(this IServiceCollection services, string connectionString) =>

--- a/src/Framework.RabbitMq.Consumer/DependencyInjection.cs
+++ b/src/Framework.RabbitMq.Consumer/DependencyInjection.cs
@@ -32,6 +32,7 @@ public static class DependencyInjection
         return services
             .Configure<RabbitMqConsumerSettings>(settingsSection)
             .AddSingleton<IRabbitMqMessageReader, MessageReader>()
+            .AddSingleton<IDeadLetterProcessor, DeadLetterProcessor>()
             .AddSingleton<IRabbitMqMessageProcessor, TMessageProcessor>()
             .AddSingleton<IRabbitMqConsumerInitializer, ConsumerInitializer>()
             .AddHostedService<RabbitMqBackgroundService>();

--- a/src/Framework.RabbitMq.Consumer/Enums/DeadLetterBehaviour.cs
+++ b/src/Framework.RabbitMq.Consumer/Enums/DeadLetterBehaviour.cs
@@ -1,8 +1,0 @@
-namespace Framework.RabbitMq.Consumer.Enums;
-
-public enum DeadLetterBehaviour
-{
-    ForeverRetry = 1,
-
-    Skip = 2
-}

--- a/src/Framework.RabbitMq.Consumer/Enums/DeadLetterDecision.cs
+++ b/src/Framework.RabbitMq.Consumer/Enums/DeadLetterDecision.cs
@@ -1,0 +1,8 @@
+namespace Framework.RabbitMq.Consumer.Enums;
+
+public enum DeadLetterDecision
+{
+    Requeue = 1,
+
+    RemoveFromQueue = 2
+}

--- a/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
@@ -1,10 +1,8 @@
 ﻿using Framework.RabbitMq.Consumer.Enums;
 
-using RabbitMQ.Client;
-
 namespace Framework.RabbitMq.Consumer.Interfaces;
 
 public interface IDeadLetterProcessor
 {
-    Task<DeadLetterDecision> ProcessAsync(IModel channel, BasicGetResult message, Exception exception);
+    Task<DeadLetterDecision> ProcessAsync(string message, string routingKey, Exception? exception, CancellationToken cancellationToken);
 }

--- a/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
@@ -6,8 +6,5 @@ namespace Framework.RabbitMq.Consumer.Interfaces;
 
 public interface IDeadLetterProcessor
 {
-    DeadLetterDecision ProcessDeadLetter(
-        IModel channel,
-        BasicGetResult message,
-        Exception exception);
+    Task<DeadLetterDecision> ProcessAsync(IModel channel, BasicGetResult message, Exception exception);
 }

--- a/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Interfaces/IDeadLetterProcessor.cs
@@ -1,0 +1,13 @@
+﻿using Framework.RabbitMq.Consumer.Enums;
+
+using RabbitMQ.Client;
+
+namespace Framework.RabbitMq.Consumer.Interfaces;
+
+public interface IDeadLetterProcessor
+{
+    DeadLetterDecision ProcessDeadLetter(
+        IModel channel,
+        BasicGetResult message,
+        Exception exception);
+}

--- a/src/Framework.RabbitMq.Consumer/Interfaces/IRabbitMqMessageProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Interfaces/IRabbitMqMessageProcessor.cs
@@ -1,17 +1,8 @@
-﻿using Framework.RabbitMq.Consumer.Enums;
-
-using RabbitMQ.Client;
+﻿using RabbitMQ.Client;
 
 namespace Framework.RabbitMq.Consumer.Interfaces;
 
 public interface IRabbitMqMessageProcessor
 {
     Task ProcessAsync(IBasicProperties properties, string routingKey, string message, CancellationToken token);
-
-    async Task<DeadLetterBehaviour> ProcessDeadLetterAsync(
-        IBasicProperties properties,
-        string routingKey,
-        string message,
-        CancellationToken token) =>
-        DeadLetterBehaviour.ForeverRetry;
 }

--- a/src/Framework.RabbitMq.Consumer/Services/DeadLetterProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Services/DeadLetterProcessor.cs
@@ -1,0 +1,44 @@
+﻿using Framework.RabbitMq.Consumer.Enums;
+using Framework.RabbitMq.Consumer.Interfaces;
+using Framework.RabbitMq.Consumer.Settings;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using RabbitMQ.Client;
+
+namespace Framework.RabbitMq.Consumer.Services;
+
+internal record DeadLetterProcessor(
+    ILogger<DeadLetterProcessor> Logger,
+    IOptions<RabbitMqConsumerSettings> ConsumerOptions) : IDeadLetterProcessor
+{
+    private readonly RabbitMqConsumerSettings _settings = ConsumerOptions.Value;
+
+    public DeadLetterDecision ProcessDeadLetter(
+        IModel channel,
+        BasicGetResult message,
+        Exception exception)
+    {
+        try
+        {
+            var properties = channel.CreateBasicProperties();
+            properties.Persistent = true;
+            properties.Headers = new Dictionary<string, object>
+                                 {
+                                     { "routingKey", message.RoutingKey },
+                                     { "queue", this._settings.Queue },
+                                     { "error", exception.Message },
+                                     { "stacktrace", exception.StackTrace ?? "missing stacktrace" }
+                                 };
+
+            channel.BasicPublish(this._settings.DeadLetterExchange, string.Empty, properties, message.Body.Span.ToArray());
+            return DeadLetterDecision.RemoveFromQueue;
+        }
+        catch (Exception e)
+        {
+            this.Logger.LogError(e, "Failed to process dead letter with routing key '{RoutingKey}'", message.RoutingKey);
+            return DeadLetterDecision.Requeue;
+        }
+    }
+}

--- a/src/Framework.RabbitMq.Consumer/Services/DeadLetterProcessor.cs
+++ b/src/Framework.RabbitMq.Consumer/Services/DeadLetterProcessor.cs
@@ -1,6 +1,9 @@
-﻿using Framework.RabbitMq.Consumer.Enums;
+﻿using System.Text;
+
+using Framework.RabbitMq.Consumer.Enums;
 using Framework.RabbitMq.Consumer.Interfaces;
 using Framework.RabbitMq.Consumer.Settings;
+using Framework.RabbitMq.Interfaces;
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -9,32 +12,44 @@ using RabbitMQ.Client;
 
 namespace Framework.RabbitMq.Consumer.Services;
 
-internal record DeadLetterProcessor(ILogger<DeadLetterProcessor> Logger, IOptions<RabbitMqConsumerSettings> ConsumerOptions)
+internal record DeadLetterProcessor(
+    IRabbitMqClient Client,
+    ILogger<DeadLetterProcessor> Logger,
+    IOptions<RabbitMqConsumerSettings> ConsumerOptions)
     : IDeadLetterProcessor
 {
     private readonly RabbitMqConsumerSettings _settings = ConsumerOptions.Value;
 
-    public Task<DeadLetterDecision> ProcessAsync(IModel channel, BasicGetResult message, Exception exception)
+    public async Task<DeadLetterDecision> ProcessAsync(
+        string message,
+        string routingKey,
+        Exception? exception,
+        CancellationToken cancellationToken)
     {
         try
         {
+            using var connection = await this.Client.TryConnectAsync(this._settings.ConnectionAttemptCount, cancellationToken);
+            if (connection == null) throw new Exception("Failed to open connection");
+
+            using var channel = connection.CreateModel();
+
             var properties = channel.CreateBasicProperties();
             properties.Persistent = true;
             properties.Headers = new Dictionary<string, object>
                                  {
-                                     { "routingKey", message.RoutingKey },
+                                     { "routingKey", routingKey },
                                      { "queue", this._settings.Queue },
-                                     { "error", exception.Message },
-                                     { "stacktrace", exception.StackTrace ?? "missing stacktrace" }
+                                     { "error", exception?.Message ?? "unknown exception" },
+                                     { "stacktrace", exception?.StackTrace ?? "missing stacktrace" }
                                  };
 
-            channel.BasicPublish(this._settings.DeadLetterExchange, string.Empty, properties, message.Body.Span.ToArray());
-            return Task.FromResult(DeadLetterDecision.RemoveFromQueue);
+            channel.BasicPublish(this._settings.DeadLetterExchange, string.Empty, properties, Encoding.UTF8.GetBytes(message));
+            return DeadLetterDecision.RemoveFromQueue;
         }
         catch (Exception e)
         {
-            this.Logger.LogError(e, "Failed to process dead letter with routing key '{RoutingKey}'", message.RoutingKey);
-            return Task.FromResult(DeadLetterDecision.Requeue);
+            this.Logger.LogError(e, "Failed to process dead letter with routing key '{RoutingKey}'", routingKey);
+            return DeadLetterDecision.Requeue;
         }
     }
 }

--- a/src/Framework.RabbitMq.Consumer/Services/MessageReader.cs
+++ b/src/Framework.RabbitMq.Consumer/Services/MessageReader.cs
@@ -19,8 +19,6 @@ internal record MessageReader(
     ILogger<MessageReader> Logger,
     IOptions<RabbitMqConsumerSettings> ConsumerOptions) : IRabbitMqMessageReader
 {
-    private const string RetryCountKey = "RetryCount";
-
     private readonly RabbitMqConsumerSettings _settings = ConsumerOptions.Value;
 
     public async Task ReadAsync(IModel channel, CancellationToken token)
@@ -28,61 +26,67 @@ internal record MessageReader(
         var result = channel.BasicGet(this._settings.Queue, false);
         if (result is null)
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(this._settings.ReceiveMessageDelayMilliseconds), token);
+            await Delay(this._settings.ReceiveMessageDelayMilliseconds, token);
             return;
         }
 
         await this.ProcessAsync(result, channel, token);
     }
 
-    private async Task ProcessAsync(BasicGetResult result, IModel channel, CancellationToken token) =>
-        await Policy
-              .HandleResult<bool>(x => !x)
-              .WaitAndRetryForeverAsync(
-                  (_, _) => TimeSpan.FromMilliseconds(this._settings.RejectMessageDelayMilliseconds),
-                  (_, retryCount, _, ctx) =>
-                  {
-                      if (!ctx.Contains(RetryCountKey))
-                          ctx.Add(RetryCountKey, retryCount);
-                      else
-                          ctx[RetryCountKey] = retryCount;
-                  })
-              .ExecuteAsync((ctx, innerToken) => this.ProcessAsync(result, channel, ctx, innerToken), new Context(), token);
+    private async Task ProcessAsync(BasicGetResult message, IModel channel, CancellationToken token)
+    {
+        var result = await Policy
+                           .Handle<Exception>()
+                           .WaitAndRetryAsync(
+                               this._settings.FailedMessageRetryCount,
+                               _ => TimeSpan.FromMilliseconds(this._settings.RejectMessageDelayMilliseconds))
+                           .ExecuteAndCaptureAsync(
+                               innerToken => this.MessageProcessor.ProcessAsync(
+                                   message.BasicProperties,
+                                   message.RoutingKey,
+                                   GetMessageBody(message),
+                                   innerToken),
+                               token);
 
-    private async Task<bool> ProcessAsync(BasicGetResult result, IModel channel, Context retryContext, CancellationToken token)
+        await this.HandleProcessResultAsync(message, channel, result, token);
+    }
+
+    private static string GetMessageBody(BasicGetResult message) => Encoding.UTF8.GetString(message.Body.Span);
+
+    private async Task HandleProcessResultAsync(BasicGetResult message, IModel channel, PolicyResult result, CancellationToken token)
     {
         try
         {
-            var message = Encoding.UTF8.GetString(result.Body.Span);
-
-            await this.MessageProcessor.ProcessAsync(result.BasicProperties, result.RoutingKey, message, token);
-            channel.BasicAck(result.DeliveryTag, false);
-            return true;
+            if (result.Outcome == OutcomeType.Successful)
+            {
+                channel.BasicAck(message.DeliveryTag, false);
+            }
+            else
+            {
+                var deadLetteringResult = await this.DeadLetterProcessor.ProcessAsync(
+                                              GetMessageBody(message),
+                                              message.RoutingKey,
+                                              result.FinalException,
+                                              token);
+                if (deadLetteringResult == DeadLetterDecision.RemoveFromQueue)
+                {
+                    channel.BasicAck(message.DeliveryTag, false);
+                }
+                else
+                {
+                    channel.BasicNack(message.DeliveryTag, false, true);
+                }
+            }
         }
         catch (Exception ex)
         {
-            return await this.RetryAsync(result, channel, retryContext, ex);
+            this.Logger.LogError(ex, "Failed to deadLetter message with routing key {RoutingKey}", message.RoutingKey);
+
+            await Delay(this._settings.ReceiveMessageDelayMilliseconds, token);
+
+            channel.BasicNack(message.DeliveryTag, false, true);
         }
     }
 
-    private async Task<bool> RetryAsync(BasicGetResult result, IModel channel, Context retryContext, Exception ex)
-    {
-        try
-        {
-            var retryCount = retryContext.Contains(RetryCountKey) ? (int?)retryContext[RetryCountKey] : null;
-            if (retryCount == null || retryCount % this._settings.FailedMessageRetryCount != 0)
-                return false;
-
-            var decision = await this.DeadLetterProcessor.ProcessAsync(channel, result, ex);
-            if (decision == DeadLetterDecision.Requeue) return false;
-
-            channel.BasicAck(result.DeliveryTag, false);
-            return true;
-        }
-        catch (Exception innerEx)
-        {
-            this.Logger.LogError(innerEx, "Failed to retry process message with routing key {RoutingKey}", result.RoutingKey);
-            return false;
-        }
-    }
+    private static Task Delay(int value, CancellationToken token) => Task.Delay(TimeSpan.FromMilliseconds(value), token);
 }

--- a/src/Framework.RabbitMq.Consumer/Services/SynchronizedConsumer.cs
+++ b/src/Framework.RabbitMq.Consumer/Services/SynchronizedConsumer.cs
@@ -62,7 +62,7 @@ internal record SynchronizedConsumer(
         if (!this.LockService.TryObtainLock(this._connection!)) return false;
 
         this._lockObtainedDate = DateTime.Now;
-        this.Logger.LogInformation("Current consumer is active");
+        this.Logger.LogDebug("Current consumer is active");
 
         return true;
     }

--- a/src/Framework.RabbitMq.Consumer/Settings/RabbitMqConsumerSettings.cs
+++ b/src/Framework.RabbitMq.Consumer/Settings/RabbitMqConsumerSettings.cs
@@ -23,12 +23,12 @@ public class RabbitMqConsumerSettings
     public ConsumerMode Mode { get; set; } = ConsumerMode.MultipleActiveConsumers;
 
     /// <summary>
-    /// for single active consumer mode - how often should consumer try to become active
+    ///     for single active consumer mode - how often should consumer try to become active
     /// </summary>
     public int InactiveConsumerSleepMilliseconds { get; set; } = 60 * 1000;
 
     /// <summary>
-    /// for single active consumer mode - how often should consumer update its active status
+    ///     for single active consumer mode - how often should consumer update its active status
     /// </summary>
     public int ActiveConsumerRefreshMilliseconds { get; set; } = 3 * 60 * 1000;
 }

--- a/src/Framework.RabbitMq.Consumer/Settings/RabbitMqConsumerSettings.cs
+++ b/src/Framework.RabbitMq.Consumer/Settings/RabbitMqConsumerSettings.cs
@@ -8,7 +8,7 @@ public class RabbitMqConsumerSettings
 
     public int RejectMessageDelayMilliseconds { get; set; } = 3000;
 
-    public ulong FailedMessageRetryCount { get; set; } = 3;
+    public int FailedMessageRetryCount { get; set; } = 3;
 
     public int? ConnectionAttemptCount { get; set; }
 
@@ -17,6 +17,8 @@ public class RabbitMqConsumerSettings
     public string Queue { get; set; } = default!;
 
     public string[] RoutingKeys { get; set; } = Array.Empty<string>();
+
+    public string DeadLetterExchange { get; set; } = "deadletters";
 
     public ConsumerMode Mode { get; set; } = ConsumerMode.MultipleActiveConsumers;
 

--- a/src/__SolutionItems/CommonAssemblyInfo.cs
+++ b/src/__SolutionItems/CommonAssemblyInfo.cs
@@ -4,9 +4,9 @@
 [assembly: AssemblyCompany("Luxoft")]
 [assembly: AssemblyCopyright("Copyright © Luxoft 2009-2023")]
 
-[assembly: AssemblyVersion("20.0.10.0")]
-[assembly: AssemblyFileVersion("20.0.10.0")]
-[assembly: AssemblyInformationalVersion("20.0.10.0")]
+[assembly: AssemblyVersion("20.0.11.0")]
+[assembly: AssemblyFileVersion("20.0.11.0")]
+[assembly: AssemblyInformationalVersion("20.0.11.0")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]


### PR DESCRIPTION
- By default send deadletters to rabbitmq exchange after several retry attempts
- Fix retries: now they use channel delivery tag and it has nothing to do with retries