### PR TITLE
fluent nhib generation - support length=2147483647 from nhib xml

### DIFF
--- a/src/_DomainDriven/Framework.DomainDriven.NHibernate/Dialect/EnhancedMsSql2012Dialect.cs
+++ b/src/_DomainDriven/Framework.DomainDriven.NHibernate/Dialect/EnhancedMsSql2012Dialect.cs
@@ -24,6 +24,12 @@ public class EnhancedMsSql2012Dialect : MsSql2012Dialect
         this.RegisterFunction("AddYears", new SQLFunctionTemplate(NHibernateUtil.DateTime, "dateadd(year,?2,?1)"));
         this.RegisterFunction("DiffDays", new SQLFunctionTemplate(NHibernateUtil.Int32, "DATEDIFF(day,?1,?2)"));
 
+    }
+
+    protected override void RegisterCharacterTypeMappings()
+    {
+        base.RegisterCharacterTypeMappings();
+
         this.RegisterColumnType(DbType.String, MaxSizeForBlob, "NVARCHAR(MAX)");
     }
 }

--- a/src/_DomainDriven/Framework.DomainDriven.NHibernate/Dialect/EnhancedMsSql2012Dialect.cs
+++ b/src/_DomainDriven/Framework.DomainDriven.NHibernate/Dialect/EnhancedMsSql2012Dialect.cs
@@ -1,4 +1,6 @@
-﻿using NHibernate;
+﻿using System.Data;
+
+using NHibernate;
 using NHibernate.Dialect;
 using NHibernate.Dialect.Function;
 
@@ -21,5 +23,7 @@ public class EnhancedMsSql2012Dialect : MsSql2012Dialect
         this.RegisterFunction("AddMonths", new SQLFunctionTemplate(NHibernateUtil.DateTime, "dateadd(month,?2,?1)"));
         this.RegisterFunction("AddYears", new SQLFunctionTemplate(NHibernateUtil.DateTime, "dateadd(year,?2,?1)"));
         this.RegisterFunction("DiffDays", new SQLFunctionTemplate(NHibernateUtil.Int32, "DATEDIFF(day,?1,?2)"));
+
+        this.RegisterColumnType(DbType.String, MaxSizeForBlob, "NVARCHAR(MAX)");
     }
 }

--- a/src/__SolutionItems/CommonAssemblyInfo.cs
+++ b/src/__SolutionItems/CommonAssemblyInfo.cs
@@ -4,9 +4,9 @@
 [assembly: AssemblyCompany("Luxoft")]
 [assembly: AssemblyCopyright("Copyright © Luxoft 2009-2024")]
 
-[assembly: AssemblyVersion("21.0.8.0")]
-[assembly: AssemblyFileVersion("21.0.8.0")]
-[assembly: AssemblyInformationalVersion("21.0.8.0")]
+[assembly: AssemblyVersion("21.0.9.0")]
+[assembly: AssemblyFileVersion("21.0.9.0")]
+[assembly: AssemblyInformationalVersion("21.0.9.0")]
 
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]


### PR DESCRIPTION
problem with auth.permission.comment from nhibernate xml file - fluent nhibernate db generation does not support length=2147483647 as max registered length for nvarchar is 1073741823. solution - register 2147483647